### PR TITLE
fixed wrong data specifier for SetCustomMetric in native UWP HitBuilder

### DIFF
--- a/src/Native/GoogleAnalytics.UWP/HitBuilder.cpp
+++ b/src/Native/GoogleAnalytics.UWP/HitBuilder.cpp
@@ -150,7 +150,7 @@ HitBuilder^ HitBuilder::SetCustomDimension(int index, Platform::String^ dimensio
 HitBuilder^ HitBuilder::SetCustomMetric(int index, long long metric)
 {
 	auto data = ref new Map<String^, String^>();
-	data->Insert("cd" + index, metric.ToString());
+	data->Insert("cm" + index, metric.ToString());
 	return ref new HitBuilder(lineage, data);
 }
 


### PR DESCRIPTION
SetCustomMetrics currently overwrites any previously set custom dimension with the same index.
Changing the data specifier from wrong "cd" to correct "cm" should fix this problem.
(in the managed implementation the specifier is already correct..)
